### PR TITLE
Fix problems with sort behavior across browsers with localeCompare

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ import { handleSearchForm } from "./search.js";
 const cuisineDropdown = document.getElementById("cuisine");
 const authorDropdown = document.getElementById("author");
 const sortDropdown = document.getElementById("sortDropdown");
-const sortOptions = Array.from(sortDropdown.options);
+const sortOptions = document.getElementById("sortDropdown");
 const searchForm = document.getElementById("searchForm");
 
 // Toogle the filter dropdown
@@ -33,10 +33,8 @@ authorDropdown.addEventListener("click", (e) => {
 });
 
 // Event listner for sort options
-sortOptions.forEach((option) => {
-  option.addEventListener("click", (e) => {
-    handleSort(recipes, e);
-  });
+sortDropdown.addEventListener("change", function (e) {
+  handleSort(recipes, e);
 });
 
 // Event listner for search form

--- a/js/search.js
+++ b/js/search.js
@@ -1,11 +1,9 @@
 import { loadRecipes } from "./loaders.js";
 
 let searchInput = document.getElementById("searchInput");
-const searchContainer = document.getElementById("search-container");
 const searchErrorMsg = document.getElementById("errMsg");
 
 const handleErrorMessage = (errMsg) => {
-  console.log(errMsg);
   searchErrorMsg.innerText = errMsg;
 };
 
@@ -15,8 +13,8 @@ const handleSearchForm = (recipes, e) => {
   const searchKey = searchInput.value.toLowerCase();
 
   const results = recipes.filter((recipe) => {
+    searchErrorMsg.innerText = "";
     return Object.values(recipe).some((value) => {
-      // console.log(value);
       if (Array.isArray(value)) {
         return value.some((item) => item.toLowerCase().includes(searchKey));
       } else if (typeof value === "string") {
@@ -25,7 +23,6 @@ const handleSearchForm = (recipes, e) => {
       return false;
     });
   });
-  console.log(results);
 
   if (results.length === 0) {
     console.log("ERROR");

--- a/js/sort.js
+++ b/js/sort.js
@@ -15,10 +15,11 @@ const handleSort = (recipes, e) => {
       sortedRecipes = sortedRecipes.sort((a, b) => a.totalTime - b.totalTime);
       break;
     case "sortAtoZ":
-      sortedRecipes = sortedRecipes.sort((a, b) => b.name < a.name);
+      // localeCompare helps resolve compatibility issues between browsers.
+      sortedRecipes.sort((a, b) => a.name.localeCompare(b.name));
       break;
     case "sortZtoA":
-      sortedRecipes = sortedRecipes.sort((a, b) => b.name > a.name);
+      sortedRecipes.sort((a, b) => b.name.localeCompare(a.name));
       break;
     case "sortLessThan10":
       sortedRecipes = sortedRecipes.filter(


### PR DESCRIPTION
## Problems with sort function across browsers. 

The functionality worked in Firefox but not in Chrome and Safari. Found a solution to add localeCompare to forces sorting to follow a specific, consistent logic based on local language settings. 

It worked but I´m not sure if this is the right way fixing this issue. 
